### PR TITLE
Refactor: Polynomial and PolynomialVector as fully-fledges C++ classes

### DIFF
--- a/src/lib/pubkey/kyber/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber.cpp
@@ -549,19 +549,6 @@ namespace
     class Kyber_Internal_Operation final
     {
     public:
-
-
-        // struct poly {
-        //     // TODO Use m_N
-        //     std::array<int16_t, 256> coeffs; // coeffs[m_N]
-        // };
-
-        // struct polyvec {
-        //     // TODO Use m_k
-        //     std::array<Polynomial, 4> vec; // vec[m_k] , use std::vector instead
-        // };
-
-
         /*************************************************
         * Name:        poly_compress
         *
@@ -614,9 +601,6 @@ namespace
 
             return r;
         }
-
-
-
 
         /*************************************************
         * Name:        polyvec_compress
@@ -867,6 +851,7 @@ namespace
 
                 cipher->encrypt( buffer );
 
+                return {};
             }
         }
 


### PR DESCRIPTION
This is the first iteration of structuring the code in a more object-oriented C++'y way. We mainly moved the `poly_*` and `polyvec_*` functions into a `Polynomial` and respective `PolynomialVector` classes. That way, downstream code can take better advantage of objects and methods to implement its algorithms.